### PR TITLE
Fix member update timestamp and password encoding

### DIFF
--- a/src/main/java/com/community/world/domain/Member.java
+++ b/src/main/java/com/community/world/domain/Member.java
@@ -66,7 +66,7 @@ public class Member implements UserDetails {
     }
     @PreUpdate
     public void PreUpdate() {
-        this.createAt = ZonedDateTime.now();
+        this.updateAt = ZonedDateTime.now();
     }
 
     @OneToMany(

--- a/src/main/java/com/community/world/service/MemberApiService.java
+++ b/src/main/java/com/community/world/service/MemberApiService.java
@@ -91,7 +91,9 @@ public class MemberApiService implements UserDetailsService {
                 .orElseThrow(() ->
                         new MemberException(LOGIN_ERROR)
                 );
-        member.setPassword(request.getUpdatePassword());
+        member.setPassword(
+                bCryptPasswordEncoder.encode(request.getUpdatePassword()));
+        member.setUpdateAt(java.time.ZonedDateTime.now());
         memberRepository.save(member);
     }
 


### PR DESCRIPTION
## Summary
- fix member PreUpdate hook to update `updateAt`
- encode password on update and set timestamp

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842c40ea8a48332abdea2200ef6534a